### PR TITLE
change scripts to start and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Your `@remix-run/*` dependencies will come from the Remix package registry.
 Once everything is installed, start the app with the following command:
 
 ```sh
-$ npm start
+$ npm run dev
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "cross-env NODE_ENV=production remix build && tsc -b",
-    "start": "concurrently \"remix run\" \"tsc -b -w\" \"nodemon --ignore app server.js\""
+    "dev": "concurrently \"remix run\" \"tsc -b -w\" \"nodemon --ignore app server.js\"",
+    "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
     "@remix-run/cli": "^0.6.0",


### PR DESCRIPTION
Thinks it's worth having these defaults? Aligns with Heroku, Next, possibly others' node script conventions.
Possibly removes question of "how to run server in prod"... and a prod script will have to be defined anyways. I bet many make this change themselves.

Feel free to discard if think unnecessary.
